### PR TITLE
Fix text-align: (start|end) for Internet Explorer 11

### DIFF
--- a/src/styles/core/feature/_alignment.scss
+++ b/src/styles/core/feature/_alignment.scss
@@ -24,6 +24,7 @@
     $start-selector: srgrid-generate-attr-selector($row-attr-name, $start-row-attr-value);
     #{$start-selector} {
         justify-content: flex-start;
+        text-align: left;
         text-align: start;
     }
 
@@ -36,6 +37,7 @@
     $end-selector: srgrid-generate-attr-selector($row-attr-name, $end-row-attr-value);
     #{$end-selector} {
         justify-content: flex-end;
+        text-align: right;
         text-align: end;
     }
 


### PR DESCRIPTION
`text-align: start` and `text-align: end` are not supported on Internet Explorer 11.
`text-align: left` and `text-align: right` will fixed the issue.